### PR TITLE
Fix error when parent container is not found (clk-521)

### DIFF
--- a/nprogress.js
+++ b/nprogress.js
@@ -245,11 +245,14 @@
       spinner && removeElement(spinner);
     }
 
-    if (parent != document.body) {
+    if (parent && parent != document.body) {
       addClass(parent, 'nprogress-custom-parent');
     }
 
-    parent.appendChild(progress);
+    if (parent) {
+      parent.appendChild(progress);
+    }
+    
     return progress;
   };
 


### PR DESCRIPTION
prevent `addClass` and `parent.appendChild` from failing if parent is not found. 